### PR TITLE
Removed messageObj field

### DIFF
--- a/angular-loggly-logger.js
+++ b/angular-loggly-logger.js
@@ -168,7 +168,7 @@
               }
               else if(angular.isObject(msg)){
                 //handling JSON objects
-                sending.messageObj = msg;
+                sending = angular.extend({}, msg, sending);
               }
               else{
                 //sending plain text


### PR DESCRIPTION
Removed messageObj field for the custom object and extended custom json
object fields to the parent json.

@ajbrown  I found that extending custom object fields to the parent json is better option.