### PR TITLE
Add main entry for browserify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-loggly-logger",
   "version": "0.1.3",
+  "main": "./angular-loggly-logger.js",
   "description": "An AngularJs service and $log decorator for Loggly",
   "repository": {
     "type": "git",


### PR DESCRIPTION
For browserify compatibility, there needs a main entry in the package.json which simply points at the entry script to use. The library could maybe do with some more work to make it npm friendly but this works as a solution in the meantime