### PR TITLE
Add support for commonjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![Join the chat at https://gitter.im/ajbrown/angular-loggly-logger](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ajbrown/angular-loggly-logger?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
-Angular Loggly Logger is a module which will decorate Angular's $log service, and provide a `LogglyLogger` service which can be used to manually send messages of any kind to the [Loggly](https://www.loggly.com) cloud log management service.
+Angular Loggly Logger is a module which will decorate Angular's $log service,
+and provide a `LogglyLogger` service which can be used to manually send messages
+of any kind to the [Loggly](https://www.loggly.com) cloud log management service.
 
 
 ### Getting Started
@@ -17,13 +19,15 @@ bower install angular-loggly-logger
 Once configured (by including "logglyLogger" as a module dependency), the `$log`
 service will automatically be decorated, and all messages logged will be handled
 as normal as well as formated and passed to LogglyLogger.sendMessage.
-The plain text messages are sent into the "json.message" field with the decorated log while custom JSON objects are sent via "json.messageObj" field as Loggly only supports one type per field.
+The plain text messages are sent into the "json.message" field with the decorated
+log while custom JSON objects are sent via "json.messageObj" field as Loggly
+only supports one type per field.
 
 To use both the decorated $log and the LogglyLogger service, you must first
 configure it with an inputToken, which is done via the LogglyLoggerProvider:
 
 ```javascript
-angular.module( 'myApp', ['logglyLogger'] )
+angular.module( 'myApp', [require('angular-loggly-logger')] )
 
   .config( function( LogglyLoggerProvider ) {
     LogglyLoggerProvider.inputToken( '<loggly input token here>' );

--- a/bower.json
+++ b/bower.json
@@ -1,27 +1,26 @@
 {
   "name": "angular-loggly-logger",
-  "version": "0.1.3",
-  "main" : "angular-loggly-logger.js",
+  "version": "0.2.0",
+  "main": "index.js",
   "keywords": ["angularjs", "loggly", "logging", "logger", "log"],
   "authors": [
     { "name": "A.J. Brown", "email": "aj@ajbrown.org" }
   ],
+  "ignore": [
+    "demo",
+    "test",
+    "Gruntfile.js",
+    "package.json",
+    "karma.conf.js",
+    "karma-e2e.conf.js",
+    "node_modules",
+    "bower_components"
+  ],
   "dependencies": {
     "angular": "~1.3.16"
-    },
-    "devDependencies": {
-        "angular-mocks": "~1.3.16",
-        "angular-loader": "~1.3.16"
-    },
-    "main" : "angular-loggly-logger.js",
-    "ignore": [
-        "demo",
-        "test",
-        "Gruntfile.js",
-        "package.json",
-        "karma.conf.js",
-        "karma-e2e.conf.js",
-        "node_modules",
-        "bower_components"
-    ]
+  },
+  "devDependencies": {
+    "angular-mocks": "~1.3.16",
+    "angular-loader": "~1.3.16"
+  }
 }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('angular-loggly-logger');
+module.exports = 'logglyLogger';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-loggly-logger",
-  "version": "0.1.3",
-  "main": "./angular-loggly-logger.js",
+  "version": "0.2.0",
+  "main": "index.js",
   "description": "An AngularJs service and $log decorator for Loggly",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The notable change of this PR is:

```diff
-angular.module( 'myApp', ['logglyLogger'] )
+angular.module( 'myApp', [require('angular-loggly-logger')] )
```

This allows the file to be directly required and used by either `browserify` or `jspm` quite nicely.

This shouldn't interfere with people who were just including the 2 script files, `angular.js` and `angular-loggly-logger.js` on the page.

The version has been bumped to `0.2.0` because of the addition of `index.js`