### PR TITLE
Ensure that angular is loaded for commonjs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-loggly-logger",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "index.js",
   "keywords": ["angularjs", "loggly", "logging", "logger", "log"],
   "authors": [

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
-require('angular-loggly-logger');
+require('angular');
+require('./angular-loggly-logger');
 module.exports = 'logglyLogger';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-loggly-logger",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "index.js",
   "description": "An AngularJs service and $log decorator for Loggly",
   "repository": {


### PR DESCRIPTION
This stops some edge case loading scenarios where `window.angular` is not available.

RE: #35