### PR TITLE
bower install --allow-root

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "shelljs": "^0.2.6"
   },
   "scripts": {
-    "postinstall": "bower install",
+    "postinstall": "bower install --allow-root",
     "start": "http-server -p 8000",
     "update-webdriver": "webdriver-manager update",
     "test": "grunt karma:unit",


### PR DESCRIPTION
Our dockerized CI environment fails to build.

During the `npm install` phase after angular-loggly-logger is downloaded `bower install` is run by the root user causing the error.

I don't think it hurts to add the `--allow-root` flag here.